### PR TITLE
fix: add missing libayatana-appindicator3 library from flatpak shared-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.nonpolynomial.intiface_central.yaml
+++ b/com.nonpolynomial.intiface_central.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --system-talk-name=org.bluez
 
 modules:
+  - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
   - name: intiface
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
- add flatpak shared-modules as a git submodule
- add the libayatana-appindicator/libayatana-appindicator-gtk3.json module to the manifest

fix flathub/com.nonpolynomial.intiface_central#7